### PR TITLE
Add GitHub Packages push step to nuget-publish.yml

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -102,3 +102,14 @@ jobs:
             Write-Host "Pushing $($pkg.FullName)..."
             dotnet nuget push $pkg.FullName --api-key '${{ secrets.NUGET_API_KEY }}' --source https://api.nuget.org/v3/index.json --skip-duplicate
           }
+
+      - name: Push package(s) to GitHub Packages
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $nupkgs = Get-ChildItem -Path 'nupkg' -Filter '*.nupkg'
+          foreach ($pkg in $nupkgs) {
+            Write-Host "Pushing $($pkg.FullName) to GitHub Packages..."
+            dotnet nuget push $pkg.FullName --api-key $env:GITHUB_TOKEN --source https://nuget.pkg.github.com/Serpensin/index.json --skip-duplicate
+          }


### PR DESCRIPTION
This update introduces a new step in the workflow to push NuGet packages to GitHub Packages. It sets the shell to PowerShell, configures the GitHub token as an environment variable, and iterates over `.nupkg` files to push each package to the specified GitHub Packages source.