### PR TITLE
Update branch trigger in nuget-publish.yml

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*.*.*'
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - master
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Changed the workflow configuration to trigger on push events to the master branch instead of the default branch.