### PR TITLE
Test

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-    branches:
-      - master
   workflow_dispatch:
     inputs:
       version:
@@ -27,6 +25,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if tag is on master
+        id: check_tag
+        shell: bash
+        run: |
+          git fetch origin master
+          if git merge-base --is-ancestor origin/master ${{ github.sha }}; then
+            echo "on_master=true" >> $GITHUB_OUTPUT
+          else
+            echo "on_master=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fail if tag is not on master
+        if: steps.check_tag.outputs.on_master != 'true'
+        run: |
+          echo "Tag is not on master. Exiting."
+          exit 1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/nuget-publish.yml` file to enforce that tags are created on the `master` branch during the NuGet publishing workflow. The changes include removing branch restrictions under the `push` trigger and adding steps to verify if a tag is on the `master` branch before proceeding with the workflow.

### Workflow trigger updates:
* Removed branch restrictions under the `push` trigger, allowing tags to trigger the workflow regardless of the branch. (`[.github/workflows/nuget-publish.ymlL7-L8](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L7-L8)`)

### Tag validation steps:
* Added a step to fetch the `master` branch and check if the current tag is an ancestor of `master`. (`[.github/workflows/nuget-publish.ymlR28-R46](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R28-R46)`)
* Introduced a conditional step to fail the workflow if the tag is not on the `master` branch. (`[.github/workflows/nuget-publish.ymlR28-R46](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R28-R46)`)