### PR TITLE
Test

### DIFF
--- a/SerpentModding/SerpentModding.csproj
+++ b/SerpentModding/SerpentModding.csproj
@@ -7,8 +7,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <PackageReadmeFile>../README.md</PackageReadmeFile>
-    <PackageLicenseFile>../LICENSE.txt</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageId>SerpentModding.CustomCSharpModules</PackageId>
     <Title>SerpentModding Custom CSharp Modules</Title>
     <Authors>Serpensin</Authors>
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Using Include="System.Windows.Forms" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
-    <None Include="../LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="../LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request includes changes to the `SerpentModding.csproj` file to update paths for packaging and ensure consistency in the project's structure.

Project configuration updates:

* Updated the `PackageReadmeFile` and `PackageLicenseFile` paths to use relative paths within the project directory instead of referencing files outside the directory. (`SerpentModding/SerpentModding.csproj`, [SerpentModding/SerpentModding.csprojL10-R11](diffhunk://#diff-574dd103041df5e4346258846780c19d95495c986f3ef5e25234fdd1edd9c4d7L10-R11))
* Adjusted the `None` item for `LICENSE.txt` to include a trailing backslash in the `PackagePath` for consistency with other items. (`SerpentModding/SerpentModding.csproj`, [SerpentModding/SerpentModding.csprojL54-R54](diffhunk://#diff-574dd103041df5e4346258846780c19d95495c986f3ef5e25234fdd1edd9c4d7L54-R54))