### PR TITLE
Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,26 +22,29 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
         run: |
           $headers = @{
             "Accept" = "application/vnd.github+json"
             "Authorization" = "Bearer $env:GH_TOKEN"
             "Content-Type" = "application/json"
           }
+          $ref = $env:REF
           $body = @{
-            ref = '${{ github.ref }}'
+            ref = $ref
             inputs = @{
               version = '1.0.0'
               dry_run = 'true'
             }
           } | ConvertTo-Json -Depth 2
           $response = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/dispatches" -Headers $headers -Method Post -Body $body
-            if ($response -ne $null) {
-                Write-Host "NuGet dry run workflow triggered successfully."
-            } else {
-                Write-Error "Failed to trigger NuGet dry run workflow."
-                exit 1
-            }
+          if ($response -ne $null) {
+              Write-Host "NuGet dry run workflow triggered successfully."
+          } else {
+              Write-Error "Failed to trigger NuGet dry run workflow."
+              exit 1
+          }
           Write-Host "nuget-publish workflow triggered. Waiting 10 seconds before polling status..."
           Start-Sleep -Seconds 10
           $maxAttempts = 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,52 @@ jobs:
         run: dotnet test SerpentModding.Tests/SerpentModding.Tests.csproj --configuration Release --verbosity normal
       - name: Trigger NuGet Dry Run Workflow
         if: ${{ success() }}
-        shell: cmd
+        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -X POST ^
-            -H "Accept: application/vnd.github+json" ^
-            -H "Authorization: Bearer %GH_TOKEN%" ^
-            https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/dispatches ^
-            -d "{\"ref\":\"${{ github.ref }}\",\"inputs\":{\"version\":\"1.0.0\",\"dry_run\":\"true\"}}"
+          $headers = @{
+            "Accept" = "application/vnd.github+json"
+            "Authorization" = "Bearer $env:GH_TOKEN"
+          }
+          $body = '{"ref":"${{ github.ref }}","inputs":{"version":"1.0.0","dry_run":"true"}}'
+          $response = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/dispatches" -Headers $headers -Method Post -Body $body
+          Write-Host "nuget-publish workflow triggered. Waiting 10 seconds before polling status..."
+          Start-Sleep -Seconds 10
+          $maxAttempts = 30
+          $attempt = 0
+          $runId = $null
+          while ($null -eq $runId -and $attempt -lt $maxAttempts) {
+            $runs = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&branch=${{ github.ref_name }}" -Headers $headers
+            $runId = $runs.workflow_runs | Where-Object { $_.name -eq 'nuget-publish' -and $_.head_sha -eq "${{ github.sha }}" } | Select-Object -First 1 -ExpandProperty id
+            if ($null -eq $runId) {
+              Start-Sleep -Seconds 5
+              $attempt++
+            }
+          }
+          if ($null -eq $runId) {
+            Write-Error "Could not find triggered nuget-publish workflow run for commit ${{ github.sha }}."
+            exit 1
+          }
+          Write-Host "Found nuget-publish runId: $runId. Polling status..."
+          $status = ""
+          $conclusion = ""
+          $pollAttempts = 0
+          while ($status -ne "completed" -and $pollAttempts -lt 60) {
+            $run = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/runs/$runId" -Headers $headers
+            $status = $run.status
+            $conclusion = $run.conclusion
+            if ($status -ne "completed") {
+              Start-Sleep -Seconds 10
+              $pollAttempts++
+            }
+          }
+          if ($status -ne "completed") {
+            Write-Error "nuget-publish workflow did not complete in time."
+            exit 1
+          }
+          if ($conclusion -ne "success") {
+            Write-Error "nuget-publish workflow failed with conclusion: $conclusion"
+            exit 1
+          }
+          Write-Host "nuget-publish workflow completed successfully."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
           REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_SHA: ${{ github.sha }}
         run: |
           $headers = @{
             "Accept" = "application/vnd.github+json"
@@ -31,6 +33,8 @@ jobs:
             "Content-Type" = "application/json"
           }
           $ref = $env:REF
+          $isPr = $env:IS_PR -eq 'true'
+          $sha = if ($isPr) { $env:PR_HEAD_SHA } else { $env:CI_SHA }
           $body = @{
             ref = $ref
             inputs = @{
@@ -52,14 +56,14 @@ jobs:
           $runId = $null
           while ($null -eq $runId -and $attempt -lt $maxAttempts) {
             $runs = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/runs" -Headers $headers
-            $runId = $runs.workflow_runs | Where-Object { $_.head_sha -eq "${{ github.sha }}" } | Select-Object -First 1 -ExpandProperty id
+            $runId = $runs.workflow_runs | Where-Object { $_.head_sha -eq $sha } | Select-Object -First 1 -ExpandProperty id
             if ($null -eq $runId) {
               Start-Sleep -Seconds 5
               $attempt++
             }
           }
           if ($null -eq $runId) {
-            Write-Error "Could not find triggered nuget-publish workflow run for commit ${{ github.sha }}."
+            Write-Error "Could not find triggered nuget-publish workflow run for commit $sha."
             exit 1
           }
           Write-Host "Found nuget-publish runId: $runId. Polling status..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           $attempt = 0
           $runId = $null
           while ($null -eq $runId -and $attempt -lt $maxAttempts) {
-            $runs = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/runs?event=workflow_dispatch&branch=${{ github.ref_name }}" -Headers $headers
-            $runId = $runs.workflow_runs | Where-Object { $_.name -eq 'nuget-publish' -and $_.head_sha -eq "${{ github.sha }}" } | Select-Object -First 1 -ExpandProperty id
+            $runs = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/runs" -Headers $headers
+            $runId = $runs.workflow_runs | Where-Object { $_.head_sha -eq "${{ github.sha }}" } | Select-Object -First 1 -ExpandProperty id
             if ($null -eq $runId) {
               Start-Sleep -Seconds 5
               $attempt++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,15 @@ jobs:
           $headers = @{
             "Accept" = "application/vnd.github+json"
             "Authorization" = "Bearer $env:GH_TOKEN"
+            "Content-Type" = "application/json"
           }
-          $body = '{"ref":"${{ github.ref }}","inputs":{"version":"1.0.0","dry_run":"true"}}'
+          $body = @{
+            ref = '${{ github.ref }}'
+            inputs = @{
+              version = '1.0.0'
+              dry_run = 'true'
+            }
+          } | ConvertTo-Json -Depth 2
           $response = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/dispatches" -Headers $headers -Method Post -Body $body
           Write-Host "nuget-publish workflow triggered. Waiting 10 seconds before polling status..."
           Start-Sleep -Seconds 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
             }
           } | ConvertTo-Json -Depth 2
           $response = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/nuget-publish.yml/dispatches" -Headers $headers -Method Post -Body $body
+            if ($response -ne $null) {
+                Write-Host "NuGet dry run workflow triggered successfully."
+            } else {
+                Write-Error "Failed to trigger NuGet dry run workflow."
+                exit 1
+            }
           Write-Host "nuget-publish workflow triggered. Waiting 10 seconds before polling status..."
           Start-Sleep -Seconds 10
           $maxAttempts = 30


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/ci.yml` to improve the handling of triggering and monitoring the NuGet dry run workflow. The changes replace the previous `cmd`-based implementation with a more robust `pwsh`-based approach, adding enhanced error handling and status polling.

### Improvements to CI Workflow:

* Switched the shell from `cmd` to `pwsh` for better scripting capabilities.
* Replaced the `curl`-based implementation with `Invoke-RestMethod` in PowerShell, which simplifies HTTP requests and improves readability.
* Added logic to poll the status of the triggered workflow using `Invoke-RestMethod` and `Start-Sleep`, ensuring the workflow run is tracked until completion or timeout.
* Implemented error handling to exit the script with appropriate error messages if the workflow fails or does not complete within the allowed time.