### PR TITLE
Update workflow for tag pushes and manual dispatch

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -127,7 +127,7 @@ jobs:
         run: dotnet pack SerpentModding/SerpentModding.csproj --configuration Release --no-build --output nupkg
 
       - name: Push package(s) to NuGet.org
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)
         shell: pwsh
         run: |
           $nupkgs = Get-ChildItem -Path 'nupkg' -Filter '*.nupkg'
@@ -137,7 +137,7 @@ jobs:
           }
 
       - name: Push package(s) to GitHub Packages
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -57,7 +57,12 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            if [ -n "${{ github.event.inputs.version }}" ]; then
+              echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            else
+              echo "Error: 'version' input is missing for workflow_dispatch event." >&2
+              exit 1
+            fi
           else
             echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -126,8 +126,20 @@ jobs:
       - name: Pack
         run: dotnet pack SerpentModding/SerpentModding.csproj --configuration Release --no-build --output nupkg
 
+      - name: Check if on default branch
+        id: check_default_branch
+        shell: bash
+        run: |
+          DEFAULT_BRANCH="master"
+          git fetch origin $DEFAULT_BRANCH
+          if git merge-base --is-ancestor origin/$DEFAULT_BRANCH ${{ github.sha }}; then
+            echo "on_default_branch=true" >> $GITHUB_OUTPUT
+          else
+            echo "on_default_branch=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Push package(s) to NuGet.org
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)
+        if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)) && steps.check_default_branch.outputs.on_default_branch == 'true'
         shell: pwsh
         run: |
           $nupkgs = Get-ChildItem -Path 'nupkg' -Filter '*.nupkg'
@@ -137,7 +149,7 @@ jobs:
           }
 
       - name: Push package(s) to GitHub Packages
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)
+        if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != true)) && steps.check_default_branch.outputs.on_default_branch == 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -131,8 +131,7 @@ jobs:
         shell: bash
         run: |
           DEFAULT_BRANCH="master"
-          git fetch origin $DEFAULT_BRANCH
-          if git merge-base --is-ancestor origin/$DEFAULT_BRANCH ${{ github.sha }}; then
+          if [ "${GITHUB_REF_NAME}" = "$DEFAULT_BRANCH" ]; then
             echo "on_default_branch=true" >> $GITHUB_OUTPUT
           else
             echo "on_default_branch=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -18,16 +18,11 @@ on:
         default: true
 
 jobs:
-  check-branch:
-    if: github.ref_name == github.event.repository.default_branch || github.event.inputs.dry_run == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "This workflow only runs on the default branch or when called with dry_run=true."
-
   build:
-    needs: check-branch
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'workflow_dispatch')
     runs-on: windows-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,6 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if tag is on master
+        if: github.event_name == 'push'
         id: check_tag
         shell: bash
         run: |
@@ -46,7 +42,7 @@ jobs:
           fi
 
       - name: Fail if tag is not on master
-        if: steps.check_tag.outputs.on_master != 'true'
+        if: github.event_name == 'push' && steps.check_tag.outputs.on_master != 'true'
         run: |
           echo "Tag is not on master. Exiting."
           exit 1
@@ -60,7 +56,11 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Update csproj version
         shell: pwsh
@@ -114,7 +114,7 @@ jobs:
         run: dotnet pack SerpentModding/SerpentModding.csproj --configuration Release --no-build --output nupkg
 
       - name: Push package(s) to NuGet.org
-        if: ${{ !inputs.dry_run && !github.event.inputs.dry_run }}
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
         shell: pwsh
         run: |
           $nupkgs = Get-ChildItem -Path 'nupkg' -Filter '*.nupkg'
@@ -124,7 +124,7 @@ jobs:
           }
 
       - name: Push package(s) to GitHub Packages
-        if: ${{ !inputs.dry_run && !github.event.inputs.dry_run }}
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -63,8 +63,16 @@ jobs:
               echo "Error: 'version' input is missing for workflow_dispatch event." >&2
               exit 1
             fi
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            else
+              echo "Invalid tag format. Expected 'v*.*.*'. Exiting." >&2
+              exit 1
+            fi
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "Unsupported event: ${GITHUB_EVENT_NAME}. Exiting." >&2
+            exit 1
           fi
 
       - name: Update csproj version


### PR DESCRIPTION
Refactor workflow conditions to support execution on tag pushes and manual dispatch events. Remove the `check-branch` job and change the `build` job to run on Windows. Enhance tag validation to only check during push events. Modify version extraction to accommodate both manual and tag events. Adjust package pushing conditions for NuGet.org and GitHub Packages to ensure they run correctly based on event type and `dry_run` input.