### PR TITLE
Update NuGet publish workflow configuration

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -105,11 +105,13 @@ jobs:
 
       - name: Push package(s) to NuGet.org
         shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           $nupkgs = Get-ChildItem -Path 'nupkg' -Filter '*.nupkg'
           foreach ($pkg in $nupkgs) {
             Write-Host "Pushing $($pkg.FullName)..."
-            dotnet nuget push $pkg.FullName --api-key '${{ secrets.NUGET_API_KEY }}' --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push $pkg.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
           }
 
       - name: Push package(s) to GitHub Packages

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,9 +1,8 @@
 name: Build and Publish NuGet
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Added a release trigger for published types and enabled manual triggering of the workflow with a required version input for NuGet package version.